### PR TITLE
Fixed Default Textures from Modular Shader props not being applied

### DIFF
--- a/Editor/ShaderGenerator.cs
+++ b/Editor/ShaderGenerator.cs
@@ -849,6 +849,7 @@ namespace VRLabs.ModularShaderSystem
             {
                 var importedShader = AssetImporter.GetAtPath($"{context.FilePath}/" + context.VariantFileName) as ShaderImporter;
                 var customTextures = context.Modules.SelectMany(x => x.Properties).Where(x => x.DefaultTextureAsset != null).ToList();
+                customTextures.AddRange(context.Shader.Properties.Where(x => x.DefaultTextureAsset != null).ToList());
                 if (importedShader != null)
                 {
                     importedShader.SetDefaultTextures(customTextures.Select(x => x.Name).ToArray(), customTextures.Select(x => x.DefaultTextureAsset).ToArray());


### PR DESCRIPTION
ApplyDefaultTextures function was only grabbing textures from the modules, but not the Shader's props themselves, this little fix addresses that

PRing to 1.0 branch as per Cibbi's request

<img width="390" alt="CleanShot 2022-03-17 at 18 23 53@2x" src="https://user-images.githubusercontent.com/3798928/158827621-2cabf1c7-ce76-4c5e-a07e-499019763564.png">

**Before**
<img width="390" alt="CleanShot 2022-03-17 at 18 24 06@2x" src="https://user-images.githubusercontent.com/3798928/158827706-04b90a69-2de4-43b3-857d-6461120740f9.png">

**After**
<img width="388" alt="CleanShot 2022-03-17 at 18 25 28@2x" src="https://user-images.githubusercontent.com/3798928/158827844-9d719766-bed0-43e3-b056-b903f01848c2.png">

