### PR TITLE
Updated position of the "VRLabs" Submenu on the "Create menu" 

### DIFF
--- a/.docs/guides/GettingStarted.md
+++ b/.docs/guides/GettingStarted.md
@@ -13,7 +13,7 @@ Once everything is imported let's start creating our first modular shader!
 
 Everything starts with a `Modular shader` asset. This Asset contains all the basic information about the shader.
 
-Create a new asset file by selecting `Assets > Create > VRLabs > Modular Shader > Modular Shader` (alternative you can bring up the `Assets` menu by right clicking in the project tab).
+Create a new asset file by selecting `Assets > Create > Shader > VRLabs > Modular Shader > Modular Shader` (alternative you can bring up the `Assets` menu by right clicking in the project tab).
 
 > [!WARNING]
 > All assets specific for the Modular Shader System like Modular Shader, Shader module and Template assets should always go inside an `Editor` folder, since they're used only in editor to generate the shaders.
@@ -31,7 +31,7 @@ After that there's the Custom editor value. If you're using a custom inspector y
 Now, let's get into the meat and let's make the base skeleton for our shader.
 This skeleton will be in the `template asset` that will be placed in the `shader template` field.
 
-Create the new template file by selecting `Assets > Create > VRLabs > Modular Shader > Template`, open the file in any text editor and paste the following code:
+Create the new template file by selecting `Assets > Create > Shader > VRLabs > Modular Shader > Template`, open the file in any text editor and paste the following code:
 
 [!code[Main](Code/BaseTemplate.txt)]
 
@@ -70,7 +70,7 @@ Perfect, now the shader has all the properties it uses. But it still doesn't out
 
 ## Creating a Module
 
-Time to create a module to give life to this shader, first create the module asset file by selecting `Assets > Create > VRLabs > Modular Shader > Shader Module`.
+Time to create a module to give life to this shader, first create the module asset file by selecting `Assets > Create > Shader > VRLabs > Modular Shader > Shader Module`.
 
 The informations area of the asset is similar to the modular shader assets, but with some key differences:
 - The id **needs** to be filled in since it's going to be used by the system to check for duplicate modules, incompatibilities, and dependencies.

--- a/.docs/guides/ModularShaderComponents/ModularShader.md
+++ b/.docs/guides/ModularShaderComponents/ModularShader.md
@@ -9,7 +9,7 @@ This Asset contains all the basic information about the shader, divided in the f
 - **Base Informations:** this part is mainly informational, but could be used by systems made to work with the modular shader system.
 - **Settings:** data here will be used to generate the shader.
 
-You can create a modular shader asset by selecting the menu `Assets > Create > VRLabs > Modular Shader > Modular Shader`.
+You can create a modular shader asset by selecting the menu `Assets > Create > Shader > VRLabs > Modular Shader > Modular Shader`.
 
 ## Basic Informations
 

--- a/.docs/guides/ModularShaderComponents/ShaderModule.md
+++ b/.docs/guides/ModularShaderComponents/ShaderModule.md
@@ -7,7 +7,7 @@ title: Shader Module
 
 A module is a component that can be added and removed from a modular shader. Like the modular shader asset it has a `Base Information` and `Settings` sections, but unlike in the modular shader, you actually need to set at least some of the `Base Information` settings, since they're used for checking module compatibility inside a modular shader.
 
-You can create a shader module asset by selecting the menu `Assets > Create > VRLabs > Modular Shader > Shader Module`.
+You can create a shader module asset by selecting the menu `Assets > Create > Shader > VRLabs > Modular Shader > Shader Module`.
 
 ## Basic Informations
 

--- a/.docs/guides/ModularShaderComponents/TemplateAssets.md
+++ b/.docs/guides/ModularShaderComponents/TemplateAssets.md
@@ -9,6 +9,6 @@ A template asset is an asset that contains shader code.
 
 Its purpose depends on where this template asset is used, for example if it's used for a function definition, it will be used for the function declaration, if it's used for the templates section of a module, it's going to just be placed as code under that keyword.
 
-You can create a template asset by selecting the menu `Assets > Create > VRLabs > Modular Shader > Template`.
+You can create a template asset by selecting the menu `Assets > Create > Shader > VRLabs > Modular Shader > Template`.
 
 The asset doesn't have an editable inspector, but you can edit the file itself in any text editor.

--- a/.docs/guides/ModularShaderComponents/TemplateCollectionAssets.md
+++ b/.docs/guides/ModularShaderComponents/TemplateCollectionAssets.md
@@ -11,4 +11,4 @@ Like the template asset it is just a text file where you can write shader code, 
 
 You can have multiple template keywords like the above, and every new one ends the previous template and starts the new one. The template name will be the name of that template keyword.
 
-You can create a template collection asset by selecting the menu `Assets > Create > VRLabs > Modular Shader > Template Collection`.
+You can create a template collection asset by selecting the menu `Assets > Create > Shader > VRLabs > Modular Shader > Template Collection`.

--- a/Editor/MSSConstants.cs
+++ b/Editor/MSSConstants.cs
@@ -41,7 +41,7 @@
         /// <summary>
         /// Default path in the create menu to place all options related to asset creation (new templates, template collections, modules, modular shaders).
         /// </summary>
-        public const string CREATE_PATH = "VRLabs/Modular Shader";
+        public const string CREATE_PATH = "Shader/VRLabs/Modular Shader";
         
         /// <summary>
         /// Default name of the subfolder of the Resources folder containing all the resources needed for the library.

--- a/Editor/Resources/MSS/MSSUIElements/EmbedLibraryWindow.uxml
+++ b/Editor/Resources/MSS/MSSUIElements/EmbedLibraryWindow.uxml
@@ -17,6 +17,6 @@
     <ui:TextField picking-mode="Ignore" label="Template extension" value="stemplate" text="stemplate" name="ExtensionField" />
     <ui:TextField picking-mode="Ignore" label="Collection extension" value="stemplatecollection" text="stemplatecollection" name="CollectionExtensionField" />
     <ui:TextField picking-mode="Ignore" label="Editor window menu path" value="VRLabs/Modular Shader" text="VRLabs/Modular Shader" name="WindowPathField" />
-    <ui:TextField picking-mode="Ignore" label="Create assets menu path" value="VRLabs/Modular Shader" text="VRLabs/Modular Shader" name="CreatePathField" />
+    <ui:TextField picking-mode="Ignore" label="Create assets menu path" value="Shader/VRLabs/Modular Shader" text="VRLabs/Modular Shader" name="CreatePathField" />
     <ui:Button text="Embed" name="EmbedButton" />
 </ui:UXML>


### PR DESCRIPTION
The "VRLabs" submenu contains options for creating various assets, and some people pointed out that it would be better fit to be under the "Shader" submenu, instead of the main "Create" menu.

Before:
![immagine](https://user-images.githubusercontent.com/12004047/158884374-edd12f0b-de21-4e60-8de6-61899ed7dc23.png)

After:
![immagine](https://user-images.githubusercontent.com/12004047/158884405-e73bc7db-e231-46f5-831b-4e13b24f0e37.png)

(images shamelessly stolen from @orels1 when he mentioned it)