### PR TITLE
Use last generated shader path as default path

### DIFF
--- a/Editor/Editors/Inspectors/ModularShaderEditor.cs
+++ b/Editor/Editors/Inspectors/ModularShaderEditor.cs
@@ -59,7 +59,7 @@ namespace VRLabs.ModularShaderSystem.UI
                 }
 
                 string path = "";
-                if (_shader.LastGeneratedShaders.Count > 0 && _shader.LastGeneratedShaders[0] != null)
+                if (_shader.LastGeneratedShaders != null &&_shader.LastGeneratedShaders.Count > 0 && _shader.LastGeneratedShaders[0] != null)
                 {
                     path = Path.GetDirectoryName(AssetDatabase.GetAssetPath(_shader.LastGeneratedShaders[0]));
                 }

--- a/Editor/Editors/Inspectors/ModularShaderEditor.cs
+++ b/Editor/Editors/Inspectors/ModularShaderEditor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -57,10 +58,20 @@ namespace VRLabs.ModularShaderSystem.UI
                     return;
                 }
 
-                string path = EditorUtility.OpenFolderPanel("Select folder", "Assets", "");
-                if (path.Length == 0)
-                    return;
+                string path = "";
+                if (_shader.LastGeneratedShaders.Count > 0 && _shader.LastGeneratedShaders[0] != null)
+                {
+                    path = Path.GetDirectoryName(AssetDatabase.GetAssetPath(_shader.LastGeneratedShaders[0]));
+                }
 
+                if (string.IsNullOrWhiteSpace(path))
+                {
+
+                    path = EditorUtility.OpenFolderPanel("Select folder", "Assets", "");
+                    if (string.IsNullOrWhiteSpace(path))
+                        return;
+
+                }
                 string localPath = Environment.CurrentDirectory;
                 localPath = localPath.Replace('\\', '/');
                 path = path.Replace(localPath + "/", "");


### PR DESCRIPTION
Previously clicking the "Generate Shader" button in the modular shader asset inspector would always prompt for a path to save the shader.

With this change it first checks if there is a previously generated shader and uses that as a path if found, prompting the user to select a path only when there isn't a previously generated shader to use