### PR TITLE
Added int type on variables

### DIFF
--- a/Editor/Scriptables/Variable.cs
+++ b/Editor/Scriptables/Variable.cs
@@ -83,6 +83,8 @@ namespace VRLabs.ModularShaderSystem
                     return $"UNITY_DECLARE_TEXCUBEARRAY({Name});";
                 case VariableType.UnityTexCubeArrayNoSampler:
                     return $"UNITY_DECLARE_TEXCUBEARRAY_NOSAMPLER({Name});";
+                case VariableType.Int:
+                    return $"int {Name};";
                 case VariableType.Custom:
                     return $"{CustomType} {Name};";
             }
@@ -144,6 +146,7 @@ namespace VRLabs.ModularShaderSystem
         UnityTex2DArrayNoSampler,
         UnityTexCubeArray,
         UnityTexCubeArrayNoSampler,
+        Int,
         Custom = 999
     }
 }


### PR DESCRIPTION
The int type was missing in the list of variable types. 

While you could use the custom type for it, it was stupid not having it in there.